### PR TITLE
fix "format ‘%lld’ expects argument of type" warning

### DIFF
--- a/src/__oct_time_binsearch__.cc
+++ b/src/__oct_time_binsearch__.cc
@@ -49,7 +49,7 @@ octave_idx_type *binsearch (const T vals[], octave_idx_type vals_len, const T ar
         //std::string msg = std::string ("Total ordering violation: neither <, >, nor == was true. ")
         //        + "vals[" + i + "] = " + val + ", arr[" + mid + "] = " + arr[mid];
         error ("Total ordering violation: neither <, >, nor == was true. i=%lld, mid=%lld",
-          i, mid);
+          static_cast<long long int> (i), static_cast<long long int> (mid));
       }
     }
     if (!found)


### PR DESCRIPTION
Expand octave_idx_type arguments to long long int to match printf format
specifier. Fixes #69.