### PR TITLE
isempty bug fix

### DIFF
--- a/inst/table.m
+++ b/inst/table.m
@@ -629,7 +629,7 @@ classdef table
     ##
     ## @end deftypefn
     function out = isempty (this)
-      out = isempty (this.VariableNames);
+      out = prod (size (this)) == 0;
     end
     
     ## -*- texinfo -*-


### PR DESCRIPTION
Fix bug where `isempty(table([]))` returned `0`.

The `isempty()` method was not checking the number of rows in a table with a non-zero number of columns.