### PR TITLE
 Fix bug when installing in GNU Octave v7.1.0

### DIFF
--- a/inst/+tablicious/+internal/load_tablicious.m
+++ b/inst/+tablicious/+internal/load_tablicious.m
@@ -37,8 +37,10 @@ function load_tablicious
   if ! isempty (qhelp_file)
     if compare_versions (version, "4.4.0", ">=") && compare_versions (version, "6.0.0", "<")
       __octave_link_register_doc__ (qhelp_file);
-    elseif compare_versions (version, "6.0.0", ">=")
+    elseif compare_versions (version, "6.0.0", ">=") && compare_versions (version, "7.1.0", "<")
       __event_manager_register_doc__ (qhelp_file);
+    elseif compare_versions (version, "7.1.0", ">=")
+      __event_manager_register_documentation__ (qhelp_file);
     endif
   endif
   

--- a/inst/+tablicious/+internal/unload_tablicious.m
+++ b/inst/+tablicious/+internal/unload_tablicious.m
@@ -21,8 +21,10 @@ function unload_tablicious
   if ! isempty (qhelp_file)
     if compare_versions (version, "4.4.0", ">=") && compare_versions (version, "6.0.0", "<")
       __octave_link_unregister_doc__ (qhelp_file);
-    elseif compare_versions (version, "6.0.0", ">=")
+    elseif compare_versions (version, "6.0.0", ">=") && compare_versions (version, "7.1.0", "<")
       __event_manager_unregister_doc__ (qhelp_file);
+    elseif compare_versions (version, "7.1.0", ">=")
+      __event_manager_unregister_documentation__ (qhelp_file);
     endif
   endif
   


### PR DESCRIPTION
Fixes #91

Some functions' names have had their name changed in "libinterp/corefcn/event-manager.cc" of the GNU Octave source code.

I've initially found out about the issue here (after facing the problem myself, as well) :
https://octave.discourse.group/t/problem-installing-tablicious-package-on-octave-7-1-0/2683/2