### PR TITLE
+tblish/+internal/mycombvec.m: Fix syntax error

### DIFF
--- a/inst/+tblish/+internal/mycombvec.m
+++ b/inst/+tblish/+internal/mycombvec.m
@@ -45,7 +45,7 @@ function out = mycombvec (vecs)
       rest = vecs(2:end);
       rest_combs = tblish.internal.mycombvec (rest);
       for i = 1:numel (a)
-        out = [out; [repmat (a(i), [size (rest_combs,1) 1]) rest_combs]];
+        out = [out; [repmat(a(i), [size(rest_combs,1), 1]), rest_combs]];
       endfor
   endswitch
 endfunction


### PR DESCRIPTION
Spaces ` ` separate elements inside brackets `[ ]`. So, that line is interpreted as

    out = [out; [repmat, (a(i), [size, (rest_combs,1), 1]), rest_combs]];

Combining comma-separated lists with parenthesis is not supported (and is probably not what was intended).

Fix the syntax errorby removing the space between function name and opening parenthesis inside brackets.

See the failing doctest: https://github.com/gnu-octave/packages/pull/401

----------

### Andrew's notes

See also: https://github.com/apjanke/octave-tablicious/issues/127